### PR TITLE
fix: handle empty YAML files and report as INFO (#2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,8 +135,28 @@ def validate_yaml_syntax(file_path: str) -> List[ValidationIssue]:
 
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
-            # Use safe_load_all to handle multiple documents
-            list(yaml.safe_load_all(file))
+            content = file.read()
+
+        if not content.strip():
+            issues.append(ValidationIssue(
+                tool="yaml",
+                severity=Severity.INFO,
+                message="File is empty. Nothing to validate.",
+                rule="empty-file",
+                file_path=file_path
+            ))
+            return issues
+
+        documents = list(yaml.safe_load_all(content))
+        if documents == [None]:
+            issues.append(ValidationIssue(
+                tool="yaml",
+                severity=Severity.INFO,
+                message="File contains no YAML COntent (parsed as null).",
+                rule="empty-file",
+                file_path=file_path
+            ))
+
     except yaml.YAMLError as e:
         line = getattr(e, 'problem_mark', None)
         line_num = line.line + 1 if line else None


### PR DESCRIPTION
## Description

yaml.safe_load_all() on an empty file returns [None] which was 
not being handled, causing silent passes or downstream issues.
Changes made:
- Read file content first before parsing
- If file is empty or whitespace-only → report as INFO with 
  message "File is empty. Nothing to validate."
- If safe_load_all returns [None] → report as INFO with 
  message "File contains no YAML content (parsed as null)."

Fixes #2  (issue)

## Type of change

Please delete options that are not relevant.

- [✔] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] `pytest tests/` (Local unit tests pass)
- [ ] Docker build passes locally

- Tested with a completely empty file → INFO reported correctly
- Tested with a whitespace-only file → INFO reported correctly  
- Tested with valid YAML → no change in behavior
- pytest tests/ passes locally

## Checklist

- [✔] My code follows the style guidelines of this project
- [✔] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✔] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
