### PR TITLE
fix: strip UTF-8 BOM from YAML files before parsing (#4)

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,7 +134,8 @@ def validate_yaml_syntax(file_path: str) -> List[ValidationIssue]:
         )]
 
     try:
-        with open(file_path, 'r', encoding='utf-8') as file:
+        # utf-8-sig is built-in encoding that silently strips \xef\xbb\xbf BOM if present
+        with open(file_path, 'r', encoding='utf-8-sig') as file:
             # Use safe_load_all to handle multiple documents
             list(yaml.safe_load_all(file))
     except yaml.YAMLError as e:


### PR DESCRIPTION
## Description

YAML files containing a UTF-8 BOM (\xef\xbb\xbf) caused 
parsing errors.
Fix: Changed file open encoding from 'utf-8' to 'utf-8-sig'.
Python's utf-8-sig codec automatically strips the BOM if 
present and reads normally if not — no behavior change for 
BOM-free files.

Fixes #4  (issue)

## Type of change

Please delete options that are not relevant.

- [✔] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Created a BOM file and validated:
  printf '\xef\xbb\xbfkey: value\n' > bom_test.yaml
  python3 app.py bom_test.yaml
  → Parses correctly, no error ✅
- Normal YAML files still validate correctly ✅
- pytest tests/ passes locally ✅

- [ ] `pytest tests/` (Local unit tests pass)
- [ ] Docker build passes locally

## Checklist

- [✔] My code follows the style guidelines of this project
- [✔] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✔] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
