### PR TITLE
fix: handle empty and binary YAML files gracefully

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -114,6 +114,35 @@ class TestValidateYamlSyntax:
         finally:
             os.unlink(path)
 
+    def test_empty_yaml_reports_info(self):
+        path = make_yaml("")
+        try:
+            issues = validate_yaml_syntax(path)
+            assert len(issues) == 1
+            assert issues[0].severity == Severity.INFO
+            assert issues[0].rule == "empty"
+        finally:
+            os.unlink(path)
+
+    def test_binary_yaml_reports_warning_and_skips(self):
+        f = tempfile.NamedTemporaryFile(suffix=".yaml", mode="wb", delete=False)
+        try:
+            f.write(b"PK\x03\x04\x00binary\x00content")
+            f.close()
+            issues = validate_yaml_syntax(f.name)
+            assert len(issues) == 1
+            assert issues[0].severity == Severity.MEDIUM
+            assert issues[0].rule == "binary"
+            result = validate_yaml_file(
+                f.name,
+                tools=ToolAvailability(yamllint=False, checkov=False),
+            )
+            assert result.syntax_valid is False
+            assert any(i.rule == "binary" for i in result.issues)
+            assert not any(i.tool == "yamllint" for i in result.issues)
+        finally:
+            os.unlink(f.name)
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # 2. run_yamllint

--- a/yaml_validator/validators.py
+++ b/yaml_validator/validators.py
@@ -54,9 +54,31 @@ def validate_yaml_syntax(file_path: str) -> List[ValidationIssue]:
         )]
 
     try:
+        # Detect binary content early (e.g. .yaml that is not text).
+        with open(file_path, 'rb') as raw:
+            sample = raw.read(8192)
+        if b'\x00' in sample:
+            return [ValidationIssue(
+                tool="yaml",
+                severity=Severity.MEDIUM,
+                message="Skipping binary file (null bytes detected); not valid YAML text",
+                rule="binary",
+                file_path=file_path,
+            )]
+
         with open(file_path, 'r', encoding='utf-8') as file:
             # Use safe_load_all to handle multiple documents
-            list(yaml.safe_load_all(file))
+            documents = list(yaml.safe_load_all(file))
+
+        # Empty / whitespace-only files yield [] or [None, ...] — report as INFO.
+        if not documents or all(doc is None for doc in documents):
+            return [ValidationIssue(
+                tool="yaml",
+                severity=Severity.INFO,
+                message="Empty YAML file (no documents)",
+                rule="empty",
+                file_path=file_path,
+            )]
     except yaml.YAMLError as e:
         mark = getattr(e, 'problem_mark', None)
         line_num = mark.line + 1 if mark else None
@@ -258,11 +280,37 @@ def validate_yaml_file(
     syntax_issues = validate_yaml_syntax(file_path)
     all_issues.extend(syntax_issues)
 
-    if syntax_issues:
+    is_binary = any(i.rule == "binary" for i in syntax_issues)
+    is_empty = any(i.rule == "empty" for i in syntax_issues)
+    blocking_syntax = [i for i in syntax_issues if i.severity not in (Severity.INFO,)]
+
+    if is_binary:
+        syntax_valid = False
+        print_colored("⚠️  Skipping further checks (binary file)", Severity.MEDIUM)
+    elif blocking_syntax:
         syntax_valid = False
         print_colored("❌ Syntax validation failed", Severity.CRITICAL)
+    elif is_empty:
+        print_colored("ℹ️  Empty YAML file", Severity.INFO)
     else:
         print_colored("✅ Syntax validation passed", Severity.INFO)
+
+    # Binary files: do not run yamllint/checkov (they expect text).
+    if is_binary:
+        summary = {
+            'total': len(all_issues),
+            'critical': len([i for i in all_issues if i.severity == Severity.CRITICAL]),
+            'high': len([i for i in all_issues if i.severity == Severity.HIGH]),
+            'medium': len([i for i in all_issues if i.severity == Severity.MEDIUM]),
+            'low': len([i for i in all_issues if i.severity == Severity.LOW]),
+            'info': len([i for i in all_issues if i.severity == Severity.INFO]),
+        }
+        return ValidationResult(
+            file_path=file_path,
+            syntax_valid=syntax_valid,
+            issues=all_issues,
+            summary=summary,
+        )
 
     # 2. Run yamllint
     print_colored("\n🔧 Running yamllint...", Severity.INFO)


### PR DESCRIPTION
﻿## Summary
- Empty YAML documents are reported as **INFO** (`rule=empty`) instead of silently passing.
- Binary `.yaml` files are detected early (null bytes), warned, and skipped for yamllint/checkov.
- Added unit tests for both cases.

Fixes #15
Fixes #16

## Test plan
- [x] `pytest tests/test_app.py::TestValidateYamlSyntax::test_empty_yaml_reports_info -v`
- [x] `pytest tests/test_app.py::TestValidateYamlSyntax::test_binary_yaml_reports_warning_and_skips -v`
